### PR TITLE
Force new line before adding entry

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -87,6 +87,11 @@ class Writer
                 throw new \InvalidArgumentException("Failed to add new key `{$key}`. As it contains invalid characters, please use only ASCII letters, digits and underscores only.");
             }
 
+            // Check if there's a newline at the end of the current stream (if not, set one)
+            if (mb_substr($this->content, -1) !== PHP_EOL) {
+                $this->content .= PHP_EOL;
+            }
+
             $this->content .= "{$key}={$value}" . PHP_EOL;
         }
 


### PR DESCRIPTION
The additional code will force a PHP_EOL at the end of the file, in case the stream does not end with one. This addresses cases, when the .env doesn't end correctly with a line break.

I did not create an issue for that. Hopefully, it's okay, that I open the pull request directly. 