### PR TITLE
Allow multiline .env variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,45 +1,45 @@
 {
-    "name": "mirazmac/dotenvwriter",
-    "type": "library",
-    "description": "A PHP library to write values to .env (DotEnv) files",
-    "keywords": [
-        "env",
-        "dot env",
-        "dot env writer",
-        "environment",
-        "variables"
-    ],
-    "homepage": "https://mirazmac.com",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Miraz Mac",
-            "email": "mirazmac@gmail.com",
-            "homepage": "https://mirazmac.com",
-            "role": "Original Author"
-        }
-    ],
-    "require": {
-        "php": ">=7.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "MirazMac\\DotEnv\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "MirazMac\\DotEnv\\Tests\\": "tests"
-        }
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "require-dev": {
-        "vlucas/phpdotenv": "^5.3",
-        "phpunit/phpunit": "^6"
-    },
-    "scripts": {
-        "phpunit": "vendor/bin/phpunit --configuration phpunit.xml"
+  "name": "mirazmac/dotenvwriter",
+  "type": "library",
+  "description": "A PHP library to write values to .env (DotEnv) files",
+  "keywords": [
+    "env",
+    "dot env",
+    "dot env writer",
+    "environment",
+    "variables"
+  ],
+  "homepage": "https://mirazmac.com",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Miraz Mac",
+      "email": "mirazmac@gmail.com",
+      "homepage": "https://mirazmac.com",
+      "role": "Original Author"
     }
+  ],
+  "require": {
+    "php": ">=7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "MirazMac\\DotEnv\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MirazMac\\DotEnv\\Tests\\": "tests"
+    }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "require-dev": {
+    "vlucas/phpdotenv": "^5.3",
+    "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+  },
+  "scripts": {
+    "phpunit": "vendor/bin/phpunit --configuration phpunit.xml"
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true">
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests</directory>

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -71,7 +71,7 @@ class Writer
      * @throws     \InvalidArgumentException If a new key contains invalid characters
      * @return     self
      */
-    public function set(string $key, string $value, bool $forceQuote = false) : self
+    public function set(string $key, string $value, bool $forceQuote = false): self
     {
         $originalValue = $value;
 
@@ -107,7 +107,7 @@ class Writer
      * @param      array  $values  The values as key => value pairs
      * @return     self
      */
-    public function setValues(array $values) : self
+    public function setValues(array $values): self
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);
@@ -122,7 +122,7 @@ class Writer
      * @param      string  $key    The key
      * @return     self
      */
-    public function delete(string $key) : self
+    public function delete(string $key): self
     {
         if ($this->exists($key)) {
             $this->content = preg_replace("/^{$key}=.*\s{0,1}/mu", '', $this->content);
@@ -138,7 +138,7 @@ class Writer
      *
      * @return     bool
      */
-    public function hasChanged() : bool
+    public function hasChanged(): bool
     {
         return $this->changed;
     }
@@ -173,7 +173,7 @@ class Writer
      *
      * @return     string
      */
-    public function getContent() : string
+    public function getContent(): string
     {
         return $this->content;
     }
@@ -187,7 +187,7 @@ class Writer
      *
      * @return     bool
      */
-    public function write(bool $force = false, ?string $destFile = null) : bool
+    public function write(bool $force = false, ?string $destFile = null): bool
     {
         if (null === $destFile) {
             $destFile = $this->sourceFile;
@@ -223,7 +223,7 @@ class Writer
      *
      * @return     bool
      */
-    protected function isValidName(string $key) : bool
+    protected function isValidName(string $key): bool
     {
         return preg_match('/^[\w\.]+$/', $key) ? true : false;
     }
@@ -231,15 +231,18 @@ class Writer
     /**
      * Parses the environment file line by line and store the variables
      */
-    protected function parse() : void
+    protected function parse(): void
     {
         $lines = preg_split('/\r\n|\r|\n/', $this->content);
-
         $currentKey = null;
         $currentValue = '';
         $isMultiline = false;
 
         foreach ($lines as $line) {
+            // Remove inline comments
+            $line = preg_replace('/#.*$/', '', $line);
+
+            // Trim the line
             $trimmedLine = trim($line);
 
             // Skip empty lines or comments
@@ -249,10 +252,12 @@ class Writer
 
             // If we are in a multiline value, append the current line
             if ($isMultiline) {
+
                 $currentValue .= PHP_EOL . $trimmedLine;
 
                 // Check if the multiline value ends
                 if (preg_match('/["\']$/', $trimmedLine)) {
+                    $currentValue = $this->stripQuotes($currentValue);
                     $this->variables[$currentKey] = $this->formatValue($currentValue);
                     $isMultiline = false;
                     $currentKey = null;
@@ -284,7 +289,7 @@ class Writer
      */
     protected function stripQuotes(string $value): string
     {
-        return preg_replace('/^(\'(.*)\'|"(.*)")$/u', '$2$3', $value);
+        return preg_replace('/^["\']|["\']$/s', '', $value);
     }
 
     /**
@@ -295,7 +300,13 @@ class Writer
      */
     protected function formatValue(string $value): string
     {
+        // First split by comment to remove any trailing comments
         $value = trim(explode('#', trim($value))[0]);
+
+        // For multi-line values, we need to handle the entire string
+        if (preg_match('/^["\'].*["\']$/s', $value)) {
+            return stripslashes($this->stripQuotes($value));
+        }
 
         return stripslashes($this->stripQuotes($value));
     }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -243,17 +243,17 @@ EOT;
         $writer = new Writer(__DIR__ . '/.env');
 
         // Test that values are parsed correctly
-        $this->assertEquals('normal value', $writer->get('SINGLE_LINE'));
-        $this->assertEquals("first line\nsecond line\nthird line", $writer->get('MULTI_LINE_DOUBLE'), 'MULTI_LINE_DOUBLE');
-        $this->assertEquals("first line\nsecond line\nthird line", $writer->get('MULTI_LINE_SINGLE'), 'MULTI_LINE_SINGLE');
-        $this->assertEquals("multi line\nwith comment", $writer->get('WITH_COMMENT'));
-        $this->assertEquals('simple_value', $writer->get('AFTER_MULTILINE'));
+        $this->assertSame('normal value', $writer->get('SINGLE_LINE'));
+        $this->assertSame("first line\nsecond line\nthird line", $writer->get('MULTI_LINE_DOUBLE'), 'MULTI_LINE_DOUBLE');
+        $this->assertSame("first line\nsecond line\nthird line", $writer->get('MULTI_LINE_SINGLE'), 'MULTI_LINE_SINGLE');
+        $this->assertSame("multi line\nwith comment", $writer->get('WITH_COMMENT'));
+        $this->assertSame('simple_value', $writer->get('AFTER_MULTILINE'));
 
         // Test that we can write back the values
         $writer->write(true);
 
         // Read the file again to ensure values were preserved
         $newWriter = new Writer(__DIR__ . '/.env');
-        $this->assertEquals($writer->getAll(), $newWriter->getAll());
+        $this->assertSame($writer->getAll(), $newWriter->getAll());
     }
 }


### PR DESCRIPTION
Issue #4 =>Update the parser to handle multiline `.env` variables (i.e. oauth private keys) 